### PR TITLE
Parte de fallos del tester corregisdos

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: pablalva <pablalva@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ksudyn <ksudyn@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/19 22:45:53 by pablalva          #+#    #+#             */
-/*   Updated: 2025/06/07 22:15:22 by pablalva         ###   ########.fr       */
+/*   Updated: 2025/06/09 20:38:49 by ksudyn           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,12 +21,12 @@
 # include <signal.h>
 # include <stdbool.h>
 # include <stdio.h>
+# include <sys/ioctl.h>
 # include <sys/stat.h>
 # include <unistd.h>
 # include <wait.h>
-#include <sys/ioctl.h>
 
-extern int g_exit_status;
+extern int			g_exit_status;
 
 typedef struct s_shell
 {
@@ -96,9 +96,10 @@ void				ctrl_minishell(int signal);
 /*   funciones de builtings */
 
 void				execute_builting(t_list *node, t_mini *mini);
-int				ft_echo(char **args);
+int					ft_echo(char **args);
 int					ft_export(char **args, t_mini *mini);
 int					export_args(char **args, t_mini *mini);
+void				export_error(char *var);
 int					print_single_export(t_list *node);
 void				nodes_order(t_mini *mini);
 void				add_or_update_variable(t_mini *mini, char *var,
@@ -106,10 +107,10 @@ void				add_or_update_variable(t_mini *mini, char *var,
 t_list				*new_node_export(char *var, char *value);
 int					is_valid_variable_export(char *var);
 int					ft_env(char **args, t_mini *mini);
-int				ft_pwd(void);
+int					ft_pwd(void);
 void				new_pwd(char *new_path);
 void				previous_pwd(void);
-int				ft_cd(char **args);
+int					ft_cd(char **args);
 int					ft_exit(char **exit_args);
 int					ft_unset(char **args, t_mini *mini);
 
@@ -187,7 +188,7 @@ int					return_fd_out(t_list *node);
 t_status_type		update_status(char **math_content, int *i,
 						t_general *data_gen);
 int					is_operator_char(char c);
-int	dir_exists(const char *filepath);
+int					dir_exists(const char *filepath);
 
 /* counters */
 

--- a/src/builtings/exit.c
+++ b/src/builtings/exit.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   exit.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: pablalva <pablalva@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ksudyn <ksudyn@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/19 18:37:07 by pablalva          #+#    #+#             */
-/*   Updated: 2025/06/05 18:50:33 by pablalva         ###   ########.fr       */
+/*   Updated: 2025/06/09 17:43:05 by ksudyn           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -80,7 +80,7 @@ static int	final_numbers(char *str, long long *result)
 // como ya no se requiere hacer la suma de 1 por el signo se retira el if
 // y el else,
 // junto a sus respectivas variebles necesarias (number e i)
-// reduciendo la funcion a una comprobacion de si str es NULL y el llamar a 
+// reduciendo la funcion a una comprobacion de si str es NULL y el llamar a
 // transformer_numbers
 
 static int	multiple_args(char **exit_args, int argc)
@@ -93,23 +93,25 @@ static int	multiple_args(char **exit_args, int argc)
 		return (2);
 	if (final_numbers(trimmed_arg, &exit_code) == 0)
 	{
-		printf("exit\n");
-		printf("minishell: exit: %s: numeric argument required\n",
-			exit_args[1]);
+		write(1, "exit\n", 5);
+		write(2, "minishell: exit: ", 18);
+		write(2, exit_args[1], ft_strlen(exit_args[1]));
+		write(2, ": numeric argument required\n", 29);
 		free(trimmed_arg);
-		return (2);
+		exit(2);
 	}
 	free(trimmed_arg);
 	if (argc > 2)
 	{
-		printf("exit\n");
-		printf("minishell: exit: too many arguments\n");
+		write(1, "exit\n", 5);
+		write(2, "minishell: exit: too many arguments\n", 36);
+		g_exit_status = 1;
 		return (-1);
 	}
-	printf("[multiple_args] exit_code raw = %lld\n", exit_code);
 	return (((exit_code % 256) + 256) % 256);
 }
-// se quita el final_numbers(trimmed_arg, &exit_code); enciam del 
+
+// se quita el final_numbers(trimmed_arg, &exit_code); enciam del
 // free(trimmed_arg, &exit_code)
 // y se mejora el return (añadiendo + 256 ) %256);
 // de esta forma ya no hay que gestionar el signo anteriormente
@@ -128,22 +130,19 @@ int	ft_exit(char **exit_args)
 	i = 0;
 	while (exit_args[i])
 		i++;
+	write(1, "exit\n", 5);
 	if (i == 1)
-	{
-		printf("exit\n");
-		exit(0);
-	}
+		exit(g_exit_status);
 	exit_status = multiple_args(exit_args, i);
 	if (exit_status == -1)
 	{
-		printf("se ha usado mi exit pero no sale por muchos argumentos\n");
 		return (1);
 	}
 	exit(exit_status);
 }
-	// printf("se ha usado mi exit con numeros\n");
-	// printf("[ft_exit] exit_status = %d\n", exit_status);
-// con estos cambios es mas legible y funciona correctamente los LLONG_MIN  
+// printf("se ha usado mi exit con numeros\n");
+// printf("[ft_exit] exit_status = %d\n", exit_status);
+// con estos cambios es mas legible y funciona correctamente los LLONG_MIN
 // y LLONG_MAX
-// y diferentes numeros entre medias y si se sale de estos numeros da el codigo 
+// y diferentes numeros entre medias y si se sale de estos numeros da el codigo
 // de error correcto

--- a/src/builtings/export.c
+++ b/src/builtings/export.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   export.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: pablalva <pablalva@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ksudyn <ksudyn@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/19 16:08:47 by pablalva          #+#    #+#             */
-/*   Updated: 2025/06/05 18:17:58 by pablalva         ###   ########.fr       */
+/*   Updated: 2025/06/09 20:29:29 by ksudyn           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -49,11 +49,13 @@ int	ft_export(char **args, t_mini *mini)
 		mini->total_nodes = list_size(&mini->first_node);
 		nodes_order(mini);
 		print_export_list(mini);
+		g_exit_status = 0;
 		return (0);
 	}
 	result = export_args(args, mini);
 	if (mini->total_nodes != count_nodes(mini))
 		printf("Export ha fallado\n");
-	return (result);
+	g_exit_status = result;
+	return (g_exit_status);
 }
 // se añade ese if al final para una mejor gestion de errores

--- a/src/builtings/utils_export.c
+++ b/src/builtings/utils_export.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   utils_export.c                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: pablalva <pablalva@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ksudyn <ksudyn@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/19 16:09:06 by pablalva          #+#    #+#             */
-/*   Updated: 2025/06/05 15:33:09 by pablalva         ###   ########.fr       */
+/*   Updated: 2025/06/09 20:38:22 by ksudyn           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,12 +32,12 @@ void	add_or_update_variable(t_mini *mini, char *var, char *value)
 	}
 	add_env_var(mini, var, value);
 }
-	// Añadir nueva variable correctamente
-	// También crea un nodo.
-	// Lo añade a la lista.
-	// Y incrementa total_nodes,que era lo que faltaba antes.
-	// Por ahora se quedara la funcion NEW_NODE_EXPORT por si acaso
-	// si se confirma que no es necesaria se eliminara
+// Añadir nueva variable correctamente
+// También crea un nodo.
+// Lo añade a la lista.
+// Y incrementa total_nodes,que era lo que faltaba antes.
+// Por ahora se quedara la funcion NEW_NODE_EXPORT por si acaso
+// si se confirma que no es necesaria se eliminara
 
 void	nodes_order(t_mini *mini)
 {
@@ -61,17 +61,6 @@ void	nodes_order(t_mini *mini)
 	}
 }
 
-int	print_single_export(t_list *node)
-{
-	if (ft_strlen(node->variable) == 1 && node->variable[0] == '_')
-		return (0);
-	if (node->content)
-		printf("declare -x %s=\"%s\"\n", node->variable, node->content);
-	else
-		printf("declare -x %s\n", node->variable);
-	return (1);
-}
-
 int	export_args(char **args, t_mini *mini)
 {
 	int		i;
@@ -93,12 +82,19 @@ int	export_args(char **args, t_mini *mini)
 			add_or_update_variable(mini, var_name, value);
 		else
 		{
-			printf("minishell: export: %s: not a valid identifier\n", var_name);
+			export_error(args[i]);
 			exit_status = 1;
 		}
 		free(var_name);
 	}
 	return (exit_status);
+}
+
+void	export_error(char *var)
+{
+	write(2, "minishell: export: ", 20);
+	write(2, var, ft_strlen(var));
+	write(2, ": not a valid identifier\n", 26);
 }
 
 t_list	*new_node_export(char *var, char *value)

--- a/src/builtings/utils_export_2.c
+++ b/src/builtings/utils_export_2.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   utils_export_2.c                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: pablalva <pablalva@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ksudyn <ksudyn@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/19 16:40:20 by pablalva          #+#    #+#             */
-/*   Updated: 2025/06/05 15:33:09 by pablalva         ###   ########.fr       */
+/*   Updated: 2025/06/09 20:38:10 by ksudyn           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,16 +16,27 @@ int	is_valid_variable_export(char *var)
 {
 	int	i;
 
-	i = 0;
 	if (!var || !var[0])
 		return (0);
-	if (!ft_isalpha(var[0]) && var[0] != '_')
+	if (!var || (!ft_isalpha(var[0]) && var[0] != '_'))
 		return (0);
-	while (var[i])
+	i = 1;
+	while (var[i] && var[i] != '=')
 	{
 		if (!ft_isalnum(var[i]) && var[i] != '_')
 			return (0);
 		i++;
 	}
+	return (1);
+}
+
+int	print_single_export(t_list *node)
+{
+	if (ft_strlen(node->variable) == 1 && node->variable[0] == '_')
+		return (0);
+	if (node->content)
+		printf("declare -x %s=\"%s\"\n", node->variable, node->content);
+	else
+		printf("declare -x %s\n", node->variable);
 	return (1);
 }

--- a/src/enviroment/utils_enviroment.c
+++ b/src/enviroment/utils_enviroment.c
@@ -6,7 +6,7 @@
 /*   By: ksudyn <ksudyn@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/19 16:13:25 by pablalva          #+#    #+#             */
-/*   Updated: 2025/06/05 20:25:25 by ksudyn           ###   ########.fr       */
+/*   Updated: 2025/06/09 18:32:16 by ksudyn           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,7 +21,10 @@ t_list	*create_env_node(char *var, char *value)
 		return (NULL);
 	ft_memset(new, 0, sizeof(t_list));
 	new->variable = ft_strdup(var);
-	new->content = ft_strdup(value);
+	if (value)
+		new->content = ft_strdup(value);
+	else
+		new->content = NULL;
 	return (new);
 }
 
@@ -31,13 +34,13 @@ void	add_env_var(t_mini *mini, char *var, char *value)
 	t_list	*temp;
 
 	new = create_env_node(var, value);
-	temp = mini->first_node;
 	if (!new)
 		return ;
 	if (!mini->first_node)
 		mini->first_node = new;
 	else
 	{
+		temp = mini->first_node;
 		while (temp->next)
 			temp = temp->next;
 		temp->next = new;

--- a/src/execution.c
+++ b/src/execution.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   execution.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: pablalva <pablalva@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ksudyn <ksudyn@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/12 11:38:39 by pablalva          #+#    #+#             */
-/*   Updated: 2025/06/07 20:22:43 by pablalva         ###   ########.fr       */
+/*   Updated: 2025/06/09 20:38:55 by ksudyn           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -40,7 +40,7 @@ void	execute_node(t_list *node, t_general *general, t_mini *mini)
 	else if (is_builting(node->cmd_path))
 	{
 		execute_builting(node, mini);
-		exit(1);
+		exit(g_exit_status);
 	}
 }
 
@@ -63,21 +63,22 @@ void	execute_builtin_with_redir(t_list *node, t_general *data_gen,
 	close(saved_stdout);
 	close(saved_stdin);
 }
-void close_unused_pipes(int pipe_index, int total_cmds, int **pipes)
+void	close_unused_pipes(int pipe_index, int total_cmds, int **pipes)
 {
-	int j;
+	int	j;
+
 	j = 0;
-	while (j < total_cmds -1)
+	while (j < total_cmds - 1)
 	{
 		if (j != pipe_index)
 			close(pipes[j][1]); // escritura
 		if (j != pipe_index - 1)
 			close(pipes[j][0]); // lectura
 		j++;
-	}		
+	}
 }
 
-void execute_list(t_list *list, t_general general, t_mini *mini)
+void	execute_list(t_list *list, t_general general, t_mini *mini)
 {
 	t_list	*current;
 	int		i;
@@ -89,7 +90,6 @@ void execute_list(t_list *list, t_general general, t_mini *mini)
 	pipe_index = 0;
 	current = list;
 	i = 0;
-
 	general.pids = gen_pid_array((size_t)total_cmds);
 	general.pipes = gen_pipes_array((size_t)total_cmds);
 	if (!general.pids)


### PR DESCRIPTION
Los errores de exit se solucionaron usando write en lugra de printf, por que requeria fptintf que no esta permitido, y usando de forma correcta en el exit la variable global.
En la funcion executions se puso exit(g_exit_status) en lugar de exit(1), perimitiendo tras un proceso hijo sacar el resultado la de la variable global.
En export se puso el g_exit_status en el return y se hizo lo mismo que el exit con los write, pero creando una funcion nueva por la norminette.
